### PR TITLE
Prevent shortcodes from rendering

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,18 +2,23 @@ import streamlit as st
 import requests
 import pandas as pd
 
-@st.cache_data(ttl=60*60*12)
+
+@st.cache_data(ttl=60 * 60 * 12)
 def fetch_emojis():
     resp = requests.get(
-        'https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json')
+        "https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json"
+    )
     json = resp.json()
     codes, emojis = zip(*json.items())
-    return pd.DataFrame({
-        'Emojis': emojis,
-        'Shortcodes': [f':{code}:' for code in codes],
-    })
+    return pd.DataFrame(
+        {
+            "Emojis": emojis,
+            "Shortcodes": [f"`:{code}:`" for code in codes],
+        }
+    )
 
-'''
+
+"""
 # Streamlit emoji shortcodes
 
 Below are all the emoji shortcodes supported by Streamlit.
@@ -23,7 +28,7 @@ Shortcodes are a way to enter emojis using pure ASCII. So you can type this `:sm
 
 (Keep in mind you can also enter emojis directly as Unicode in your Python strings too — you don't
 *have to* use a shortcode.)
-'''
+"""
 
 st.info(
     """


### PR DESCRIPTION
Since tables now render Markdown, the shortcodes for the emojis a rendering instead of displaying as text. This PR uses backticks to ensure that the shortcodes are rendered as text.

(Also reformatting with black.)